### PR TITLE
Update incorrect file extension in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@react-native-admob/admob",
   "version": "0.1.5",
   "description": "Admob for React Native with powerful hooks and components",
-  "main": "src/index.js",
+  "main": "src/index.ts",
   "files": [
     "src",
     "android",


### PR DESCRIPTION
Since there is no `src/index.js` file metro raises an error while bundling. Changing the file extension to `.ts` resolves the issue in my end.

**Error**

Error: While trying to resolve module `@react-native-admob/admob` from file `/file/path/App.js`, the package `/file/path/node_modules/@react-native-admob/admob/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/file/path/node_modules/@react-native-admob/admob/src/index.js`.