### PR TITLE
Add `adLoaded`, `adFailedToLoad` events

### DIFF
--- a/android/src/main/java/com/rnadmob/admob/RNAdMobAppOpenAdModule.java
+++ b/android/src/main/java/com/rnadmob/admob/RNAdMobAppOpenAdModule.java
@@ -1,7 +1,9 @@
 package com.rnadmob.admob;
 
 import static com.rnadmob.admob.RNAdMobEventModule.AD_DISMISSED;
+import static com.rnadmob.admob.RNAdMobEventModule.AD_FAILED_TO_LOAD;
 import static com.rnadmob.admob.RNAdMobEventModule.AD_FAILED_TO_PRESENT;
+import static com.rnadmob.admob.RNAdMobEventModule.AD_LOADED;
 import static com.rnadmob.admob.RNAdMobEventModule.AD_PRESENTED;
 
 import android.app.Activity;
@@ -89,11 +91,18 @@ public class RNAdMobAppOpenAdModule extends ReactContextBaseJavaModule {
                             appOpenAd = ad;
                             loadTime = (new Date()).getTime();
                             promise.resolve(null);
+
+                            sendEvent(AD_LOADED, null);
                         }
 
                         @Override
                         public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
                             promise.reject(String.valueOf(loadAdError.getCode()), loadAdError.getMessage());
+
+                            WritableMap error = Arguments.createMap();
+                            error.putInt("code", loadAdError.getCode());
+                            error.putString("message", loadAdError.getMessage());
+                            sendEvent(AD_FAILED_TO_LOAD, error);
                         }
                     });
         });

--- a/android/src/main/java/com/rnadmob/admob/RNAdMobEventModule.java
+++ b/android/src/main/java/com/rnadmob/admob/RNAdMobEventModule.java
@@ -14,6 +14,8 @@ public class RNAdMobEventModule extends ReactContextBaseJavaModule {
     public static final String AD_FAILED_TO_PRESENT = "adFailedToPresent";
     public static final String AD_PRESENTED = "adPresented";
     public static final String AD_DISMISSED = "adDismissed";
+    public static final String AD_LOADED = "adLoaded";
+    public static final String AD_FAILED_TO_LOAD = "adFailedToLoad";
     public static final String REWARDED = "rewarded";
 
     private static ReactContext mContext;

--- a/android/src/main/java/com/rnadmob/admob/RNAdMobInterstitialAdModule.java
+++ b/android/src/main/java/com/rnadmob/admob/RNAdMobInterstitialAdModule.java
@@ -1,7 +1,9 @@
 package com.rnadmob.admob;
 
 import static com.rnadmob.admob.RNAdMobEventModule.AD_DISMISSED;
+import static com.rnadmob.admob.RNAdMobEventModule.AD_FAILED_TO_LOAD;
 import static com.rnadmob.admob.RNAdMobEventModule.AD_FAILED_TO_PRESENT;
+import static com.rnadmob.admob.RNAdMobEventModule.AD_LOADED;
 import static com.rnadmob.admob.RNAdMobEventModule.AD_PRESENTED;
 
 import android.app.Activity;
@@ -100,11 +102,18 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
                             adHolder.add(requestId, ad);
 
                             promise.resolve(null);
+
+                            sendEvent(AD_LOADED, requestId, null);
                         }
 
                         @Override
                         public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
                             promise.reject(String.valueOf(loadAdError.getCode()), loadAdError.getMessage());
+
+                            WritableMap error = Arguments.createMap();
+                            error.putInt("code", loadAdError.getCode());
+                            error.putString("message", loadAdError.getMessage());
+                            sendEvent(AD_FAILED_TO_LOAD, requestId, error);
                         }
                     });
         });

--- a/android/src/main/java/com/rnadmob/admob/RNAdMobRewardedAdModule.java
+++ b/android/src/main/java/com/rnadmob/admob/RNAdMobRewardedAdModule.java
@@ -1,7 +1,9 @@
 package com.rnadmob.admob;
 
 import static com.rnadmob.admob.RNAdMobEventModule.AD_DISMISSED;
+import static com.rnadmob.admob.RNAdMobEventModule.AD_FAILED_TO_LOAD;
 import static com.rnadmob.admob.RNAdMobEventModule.AD_FAILED_TO_PRESENT;
+import static com.rnadmob.admob.RNAdMobEventModule.AD_LOADED;
 import static com.rnadmob.admob.RNAdMobEventModule.AD_PRESENTED;
 import static com.rnadmob.admob.RNAdMobEventModule.REWARDED;
 
@@ -102,11 +104,18 @@ public class RNAdMobRewardedAdModule extends ReactContextBaseJavaModule {
                             adHolder.add(requestId, ad);
 
                             promise.resolve(null);
+
+                            sendEvent(AD_LOADED, requestId, null);
                         }
 
                         @Override
                         public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
                             promise.reject(String.valueOf(loadAdError.getCode()), loadAdError.getMessage());
+
+                            WritableMap error = Arguments.createMap();
+                            error.putInt("code", loadAdError.getCode());
+                            error.putString("message", loadAdError.getMessage());
+                            sendEvent(AD_FAILED_TO_LOAD, requestId, error);
                         }
                     });
         });

--- a/android/src/main/java/com/rnadmob/admob/RNAdMobRewardedInterstitialAdModule.java
+++ b/android/src/main/java/com/rnadmob/admob/RNAdMobRewardedInterstitialAdModule.java
@@ -1,7 +1,9 @@
 package com.rnadmob.admob;
 
 import static com.rnadmob.admob.RNAdMobEventModule.AD_DISMISSED;
+import static com.rnadmob.admob.RNAdMobEventModule.AD_FAILED_TO_LOAD;
 import static com.rnadmob.admob.RNAdMobEventModule.AD_FAILED_TO_PRESENT;
+import static com.rnadmob.admob.RNAdMobEventModule.AD_LOADED;
 import static com.rnadmob.admob.RNAdMobEventModule.AD_PRESENTED;
 import static com.rnadmob.admob.RNAdMobEventModule.REWARDED;
 
@@ -102,11 +104,18 @@ public class RNAdMobRewardedInterstitialAdModule extends ReactContextBaseJavaMod
                             adHolder.add(requestId, ad);
 
                             promise.resolve(null);
+
+                            sendEvent(AD_LOADED, requestId, null);
                         }
 
                         @Override
                         public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
                             promise.reject(String.valueOf(loadAdError.getCode()), loadAdError.getMessage());
+
+                            WritableMap error = Arguments.createMap();
+                            error.putInt("code", loadAdError.getCode());
+                            error.putString("message", loadAdError.getMessage());
+                            sendEvent(AD_FAILED_TO_LOAD, requestId, error);
                         }
                     });
         });

--- a/docs/docs/api/AppOpenAd.md
+++ b/docs/docs/api/AppOpenAd.md
@@ -68,7 +68,7 @@ You don't need to call this function if you set `showOnAppForeground` option to 
 
 **Returns**
 
-`Promise` that waits for ad present. When error is occured while presenting ad, the Promise will reject with `Error` object.
+`Promise` that waits for ad present. When error is occurred while presenting ad, the Promise will reject with `Error` object.
 
 ### addEventListener()
 
@@ -82,11 +82,13 @@ Adds an event handler for an ad event.
 
 `event` : Event name. Supported events:
 
-| Event Name        | Description                                                                                           |
-| ----------------- | ----------------------------------------------------------------------------------------------------- |
-| adPresented       | Fires when the ad is presented to user.                                                               |
-| adFailedToPresent | Fires when an error occured while presenting ad. The argument to the event handler is `Error` object. |
-| adDismissed       | Fires when the ad is dismissed.                                                                       |
+| Event Name        | Description                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| adLoaded          | Fires when the ad has finished loading.                                                                |
+| adFailedToLoad    | Fires when the ad has failed to load. The argument to the event handler is `Error` object.             |
+| adPresented       | Fires when the ad is presented to user.                                                                |
+| adFailedToPresent | Fires when an error occurred while presenting ad. The argument to the event handler is `Error` object. |
+| adDismissed       | Fires when the ad is dismissed.                                                                        |
 
 `handler` : An event handler.
 

--- a/docs/docs/api/InterstitialAd.md
+++ b/docs/docs/api/InterstitialAd.md
@@ -72,7 +72,7 @@ Ad must be loaded before calling this function.
 
 **Returns**
 
-`Promise` that waits for ad present. When error is occured while presenting ad, the Promise will reject with `Error` object.
+`Promise` that waits for ad present. When error is occurred while presenting ad, the Promise will reject with `Error` object.
 
 ### addEventListener()
 
@@ -86,11 +86,13 @@ Adds an event handler for an ad event.
 
 `event` : Event name. Supported events:
 
-| Event Name        | Description                                                                                           |
-| ----------------- | ----------------------------------------------------------------------------------------------------- |
-| adPresented       | Fires when the ad is presented to user.                                                               |
-| adFailedToPresent | Fires when an error occured while presenting ad. The argument to the event handler is `Error` object. |
-| adDismissed       | Fires when the ad is dismissed.                                                                       |
+| Event Name        | Description                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| adLoaded          | Fires when the ad has finished loading.                                                                |
+| adFailedToLoad    | Fires when the ad has failed to load. The argument to the event handler is `Error` object.             |
+| adPresented       | Fires when the ad is presented to user.                                                                |
+| adFailedToPresent | Fires when an error occurred while presenting ad. The argument to the event handler is `Error` object. |
+| adDismissed       | Fires when the ad is dismissed.                                                                        |
 
 `handler` : An event handler.
 

--- a/docs/docs/api/RewardedAd.md
+++ b/docs/docs/api/RewardedAd.md
@@ -58,7 +58,7 @@ Can not call this function if the ad is already loaded but not presented and dis
 
 **Returns**
 
-`Promise` that waits for ad load. When error is occured while loading ad, the Promise will reject with `Error` object.
+`Promise` that waits for ad load. When error is occurred while loading ad, the Promise will reject with `Error` object.
 
 ### show()
 
@@ -72,7 +72,7 @@ Ad must be loaded before calling this function.
 
 **Returns**
 
-`Promise` that waits for ad present. When error is occured while presenting ad, the Promise will reject with `Error` object.
+`Promise` that waits for ad present. When error is occurred while presenting ad, the Promise will reject with `Error` object.
 
 ### addEventListener()
 
@@ -86,12 +86,14 @@ Adds an event handler for an ad event.
 
 `event` : Event name. Supported events:
 
-| Event Name        | Description                                                                                           |
-| ----------------- | ----------------------------------------------------------------------------------------------------- |
-| adPresented       | Fires when the ad is presented to user.                                                               |
-| adFailedToPresent | Fires when an error occured while presenting ad. The argument to the event handler is `Error` object. |
-| adDismissed       | Fires when the ad is dismissed.                                                                       |
-| rewarded          | Fires when user earned reward. The argument to the event handler is Reward object.                    |
+| Event Name        | Description                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| adLoaded          | Fires when the ad has finished loading.                                                                |
+| adFailedToLoad    | Fires when the ad has failed to load. The argument to the event handler is `Error` object.             |
+| adPresented       | Fires when the ad is presented to user.                                                                |
+| adFailedToPresent | Fires when an error occurred while presenting ad. The argument to the event handler is `Error` object. |
+| adDismissed       | Fires when the ad is dismissed.                                                                        |
+| rewarded          | Fires when user earned reward. The argument to the event handler is Reward object.                     |
 
 `handler` : An event handler.
 

--- a/docs/docs/api/RewardedInterstitialAd.md
+++ b/docs/docs/api/RewardedInterstitialAd.md
@@ -58,7 +58,7 @@ Can not call this function if the ad is already loaded but not presented and dis
 
 **Returns**
 
-`Promise` that waits for ad load. When error is occured while loading ad, the Promise will reject with `Error` object.
+`Promise` that waits for ad load. When error is occurred while loading ad, the Promise will reject with `Error` object.
 
 ### show()
 
@@ -72,7 +72,7 @@ Ad must be loaded before calling this function.
 
 **Returns**
 
-`Promise` that waits for ad present. When error is occured while presenting ad, the Promise will reject with `Error` object.
+`Promise` that waits for ad present. When error is occurred while presenting ad, the Promise will reject with `Error` object.
 
 ### addEventListener()
 
@@ -86,12 +86,14 @@ Adds an event handler for an ad event.
 
 `event` : Event name. Supported events:
 
-| Event Name        | Description                                                                                           |
-| ----------------- | ----------------------------------------------------------------------------------------------------- |
-| adPresented       | Fires when the ad is presented to user.                                                               |
-| adFailedToPresent | Fires when an error occured while presenting ad. The argument to the event handler is `Error` object. |
-| adDismissed       | Fires when the ad is dismissed.                                                                       |
-| rewarded          | Fires when user earned reward. The argument to the event handler is Reward object.                    |
+| Event Name        | Description                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| adLoaded          | Fires when the ad has finished loading.                                                                |
+| adFailedToLoad    | Fires when the ad has failed to load. The argument to the event handler is `Error` object.             |
+| adPresented       | Fires when the ad is presented to user.                                                                |
+| adFailedToPresent | Fires when an error occurred while presenting ad. The argument to the event handler is `Error` object. |
+| adDismissed       | Fires when the ad is dismissed.                                                                        |
+| rewarded          | Fires when user earned reward. The argument to the event handler is Reward object.                     |
 
 `handler` : An event handler.
 

--- a/ios/RNAdMobInterstitial.m
+++ b/ios/RNAdMobInterstitial.m
@@ -63,14 +63,19 @@ RCT_EXPORT_METHOD(requestAd:(NSNumber *_Nonnull)requestId
                       completionHandler:^(GADInterstitialAd *ad, NSError *error) {
         if (error) {
             reject(@"E_AD_LOAD_FAILED", [error localizedDescription], error);
+            
+            NSDictionary *jsError = RCTJSErrorFromCodeMessageAndNSError(@"E_AD_LOAD_FAILED", error.localizedDescription, error);
+            [self sendEvent:kEventAdFailedToLoad requestId:requestId data:jsError];
             return;
         }
+
         ad.fullScreenContentDelegate = self;
         
         requestIdMap[ad.responseInfo.responseIdentifier] = requestId;
         adMap[requestId] = ad;
         
         resolve(nil);
+        [self sendEvent:kEventAdLoaded requestId:requestId data:nil];
     }];
 }
 
@@ -93,7 +98,7 @@ RCT_EXPORT_METHOD(presentAd:(NSNumber *_Nonnull)requestId resolver:(RCTPromiseRe
     [RNAdMobEvent sendEvent:eventName type:@"Interstitial" requestId:requestId data:data];
 }
 
-- (void)removeAdMap:(NSNumber *)requestId requestIdMapKey:(NSNumber *)requestIdMapKey;
+- (void)removeAdMap:(NSNumber *)requestId requestIdMapKey:(NSString *)requestIdMapKey
 {
     [requestIdMap removeObjectForKey:requestIdMapKey];
     [adMap removeObjectForKey:requestId];

--- a/ios/RNAdMobRewarded.m
+++ b/ios/RNAdMobRewarded.m
@@ -63,6 +63,9 @@ RCT_EXPORT_METHOD(requestAd:(NSNumber *_Nonnull)requestId
                   completionHandler:^(GADRewardedAd *ad, NSError *error) {
         if (error) {
             reject(@"E_AD_LOAD_FAILED", [error localizedDescription], error);
+
+            NSDictionary *jsError = RCTJSErrorFromCodeMessageAndNSError(@"E_AD_LOAD_FAILED", error.localizedDescription, error);
+            [self sendEvent:kEventAdFailedToLoad requestId:requestId data:jsError];
             return;
         }
         
@@ -72,6 +75,7 @@ RCT_EXPORT_METHOD(requestAd:(NSNumber *_Nonnull)requestId
         adMap[requestId] = ad;
         
         resolve(nil);
+        [self sendEvent:kEventAdLoaded requestId:requestId data:nil];
     }];
 }
 
@@ -98,7 +102,7 @@ RCT_EXPORT_METHOD(presentAd:(NSNumber *_Nonnull)requestId resolver:(RCTPromiseRe
     [RNAdMobEvent sendEvent:eventName type:@"Rewarded" requestId:requestId data:data];
 }
 
-- (void)removeAdMap:(NSNumber *)requestId requestIdMapKey:(NSNumber *)requestIdMapKey;
+- (void)removeAdMap:(NSNumber *)requestId requestIdMapKey:(NSString *)requestIdMapKey
 {
     [requestIdMap removeObjectForKey:requestIdMapKey];
     [adMap removeObjectForKey:requestId];

--- a/ios/RNAdMobRewardedInterstitial.m
+++ b/ios/RNAdMobRewardedInterstitial.m
@@ -63,6 +63,9 @@ RCT_EXPORT_METHOD(requestAd:(NSNumber *_Nonnull)requestId
                               completionHandler:^(GADRewardedInterstitialAd *ad, NSError *error) {
         if (error) {
             reject(@"E_AD_LOAD_FAILED", [error localizedDescription], error);
+            
+            NSDictionary *jsError = RCTJSErrorFromCodeMessageAndNSError(@"E_AD_LOAD_FAILED", error.localizedDescription, error);
+            [self sendEvent:kEventAdFailedToLoad requestId:requestId data:jsError];
             return;
         }
         
@@ -72,6 +75,7 @@ RCT_EXPORT_METHOD(requestAd:(NSNumber *_Nonnull)requestId
         adMap[requestId] = ad;
         
         resolve(nil);
+        [self sendEvent:kEventAdLoaded requestId:requestId data:nil];
     }];
 }
 
@@ -98,7 +102,7 @@ RCT_EXPORT_METHOD(presentAd:(NSNumber *_Nonnull)requestId resolver:(RCTPromiseRe
     [RNAdMobEvent sendEvent:eventName type:@"RewardedInterstitial" requestId:requestId data:data];
 }
 
-- (void)removeAdMap:(NSNumber *)requestId requestIdMapKey:(NSNumber *)requestIdMapKey;
+- (void)removeAdMap:(NSNumber *)requestId requestIdMapKey:(NSString *)requestIdMapKey
 {
     [requestIdMap removeObjectForKey:requestIdMapKey];
     [adMap removeObjectForKey:requestId];

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export type RequestOptions = {
   requestNonPersonalizedAdsOnly?: boolean;
 
   /**
-   * Additional properties attatched to an ad request.
+   * Additional properties attached to an ad request.
    *
    * Takes an array of string key/value pairs.
    *
@@ -155,7 +155,7 @@ export interface GAMBannerAdProps extends BannerAdProps {
    */
   sizes?: string[];
   /**
-   * A callback that gets called when the Ad Manager specific app events occured. Availbale only in Ad Manager Ad.
+   * A callback that gets called when the Ad Manager specific app events occurred. Available only in Ad Manager Ad.
    */
   onAppEvent?: (name: string, info: string) => void;
 }
@@ -169,13 +169,15 @@ export type AdType =
 export type FullScreenAdEvent =
   | 'adPresented'
   | 'adFailedToPresent'
-  | 'adDismissed';
+  | 'adDismissed'
+  | 'adLoaded'
+  | 'adFailedToLoad';
 
 export type InterstitialAdEvent = FullScreenAdEvent;
 
 export type RewardedAdEvent = FullScreenAdEvent | 'rewarded';
 
-export type AppOpenAdEvent = FullScreenAdEvent | 'adLoaded' | 'adFailedToLoad';
+export type AppOpenAdEvent = FullScreenAdEvent;
 
 export type HandlerType = (() => void) | ((error: Error) => void);
 


### PR DESCRIPTION
In my case, If I'm not using hooks, `loaded` and `failedToLoad` events are useful. Especially if we were using `@firebase/admob`.

I hope this helps.