### PR TITLE
fix: Fix `loadOnDismissed` option error in iOS

### DIFF
--- a/ios/RNAdMobInterstitial.m
+++ b/ios/RNAdMobInterstitial.m
@@ -185,7 +185,7 @@ RCT_REMAP_METHOD(presentAd, requestId:(NSNumber *_Nonnull)requestId resolver:(RC
     if (options == nil) {
         return;
     }
-    if ([options valueForKey:@"loadOnDismissed"]) {
+    if (options[@"loadOnDismissed"] && [options[@"loadOnDismissed"] boolValue]) {
         [self requestAd:requestId unitId:ad.adUnitID options:options resolver:nil rejecter:nil];
     }
 }

--- a/ios/RNAdMobRewarded.m
+++ b/ios/RNAdMobRewarded.m
@@ -191,7 +191,7 @@ RCT_REMAP_METHOD(presentAd, requestId:(NSNumber *_Nonnull)requestId resolver:(RC
     if (options == nil) {
         return;
     }
-    if ([options valueForKey:@"loadOnDismissed"]) {
+    if (options[@"loadOnDismissed"] && [options[@"loadOnDismissed"] boolValue]) {
         [self requestAd:requestId unitId:ad.adUnitID options:options resolver:nil rejecter:nil];
     }
 }

--- a/ios/RNAdMobRewardedInterstitial.m
+++ b/ios/RNAdMobRewardedInterstitial.m
@@ -191,7 +191,7 @@ RCT_REMAP_METHOD(presentAd, requestId:(NSNumber *_Nonnull)requestId resolver:(RC
     if (options == nil) {
         return;
     }
-    if ([options valueForKey:@"loadOnDismissed"]) {
+    if (options[@"loadOnDismissed"] && [options[@"loadOnDismissed"] boolValue]) {
         [self requestAd:requestId unitId:ad.adUnitID options:options resolver:nil rejecter:nil];
     }
 }


### PR DESCRIPTION
There is a problem with the execution related to `loadOnDismissed` option.
