### PR TITLE
Typo correction in setRequestConfiguration of Docs

### DIFF
--- a/docs/docs/api/setRequestConfiguration.md
+++ b/docs/docs/api/setRequestConfiguration.md
@@ -13,7 +13,7 @@ import AdMob from '@react-native-admob/admob';
 
 const config = {
   testDeviceIds: ["YOUR_TEST_DEVICE_ID"],
-  maxAdContetRating: "MA",
+  maxAdContentRating: "MA",
   tagForChildDirectedTreatment: false,
   tagForUnderAgeConsent: false,
 };


### PR DESCRIPTION
Hello! I'm using your library well. I'm sending you a full request because I found a typo while using it.

maxAdContetRating -> maxAdContentRating