### PR TITLE
feat: add targets in requestOptions

### DIFF
--- a/android/src/main/java/com/rnadmob/admob/RNAdMobCommon.java
+++ b/android/src/main/java/com/rnadmob/admob/RNAdMobCommon.java
@@ -120,6 +120,16 @@ public class RNAdMobCommon {
             builder.setLocation(location);
         }
 
+        if (requestOptions.hasKey("targets")) {
+            Map<String, Object> networkExtras = Objects.requireNonNull(requestOptions.getMap("targets")).toHashMap();
+
+            for (Map.Entry<String, Object> entry : networkExtras.entrySet()) {
+                String key = entry.getKey();
+                String value = (String) entry.getValue();
+                builder.addCustomTargeting(key, value);
+            }
+        }
+
         return builder.build();
     }
 }

--- a/docs/docs/api/RequestOptions.md
+++ b/docs/docs/api/RequestOptions.md
@@ -55,3 +55,11 @@ Content URL for targeting purposes. Max length of 512.
 | Type   |
 | :----- |
 | string |
+
+### `targets`
+
+Custom key-value pairs to target Google Ad Manager campaigns.
+
+| Type                      |
+| :------------------------ |
+| { [key: string]: string } |

--- a/ios/RNAdMobCommon.m
+++ b/ios/RNAdMobCommon.m
@@ -81,6 +81,7 @@
 + (GAMRequest *)buildAdRequest:(NSDictionary *)requestOptions {
     GAMRequest *request = [GAMRequest request];
     NSMutableDictionary *extras = [@{} mutableCopy];
+    NSMutableDictionary *targets = [@{} mutableCopy];
 
     if (requestOptions[@"requestNonPersonalizedAdsOnly"] && [requestOptions[@"requestNonPersonalizedAdsOnly"] boolValue]) {
         extras[@"npa"] = @"1";
@@ -109,6 +110,15 @@
     if (requestOptions[@"contentUrl"]) {
         request.contentURL = requestOptions[@"contentUrl"];
     }
+    
+    if (requestOptions[@"targets"]) {
+        for (NSString *key in requestOptions[@"targets"]) {
+            NSString *value = requestOptions[@"targets"][key];
+            targets[key] = value;
+        }
+    }
+    
+    request.customTargeting = targets;
     
     return request;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,7 +102,23 @@ export type RequestOptions = {
    * @ios
    */
   locationAccuracy?: number;
-};
+
+  /**
+   * Custom key-value pairs to target Google Ad Manager campaigns.
+   *
+   * Takes an object.
+   *
+   * #### Example
+   *
+   * ```js
+   * await interstitialAd.requestAd({
+   *   targets: {
+   *     age: '25',
+   *   },
+   * });
+   */
+  targets?: { [key: string]: string };
+}
 
 export type InitializationStatus = {
   name: string;


### PR DESCRIPTION
## Description

This PR implements custom targeting options in the requestOptions.

Fixes #38 .

## Changes

- Added `targets` option in `requestOptions`
- Updated `readme.md` docs

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Updated documentation
- [x] Ensured that CI passes
