### PR TITLE
fix(ios): use topmost view controller

### DIFF
--- a/ios/Ads/RNAdMobFullScreenAd.swift
+++ b/ios/Ads/RNAdMobFullScreenAd.swift
@@ -23,7 +23,18 @@ class RNAdMobFullScreenAd<T>: NSObject {
     }
     
     func getViewController(reject: RCTPromiseRejectBlock?) -> UIViewController? {
-        let viewController = RCTPresentedViewController()
+        var viewController = RCTKeyWindow()?.rootViewController
+        while true {
+            if let presented = viewController?.presentedViewController {
+                viewController = presented
+            } else if let nav = viewController as? UINavigationController {
+                viewController = nav.visibleViewController
+            } else if let tab = viewController as? UITabBarController {
+                viewController = tab.selectedViewController
+            } else {
+                break
+            }
+        }
         if (viewController == nil && reject != nil) {
             reject!("E_NIL_VC", "Cannot process Ad because the current View Controller is nil.", nil)
         }


### PR DESCRIPTION
## Description

Added logic to find topmost presenting view controller.
This fixes problem ad is not showing when current presenting controller is differ from RCTPresentedViewController.

Fixes #59.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Updated documentation
- [ ] Ensured that CI passes
