### PR TITLE
fix: AdMob export error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-export { default as AdMob } from './AdMob';
-export * from './AdMob';
+import AdMob from './AdMob';
+export default AdMob;
+
 export * from './ads';
 export * from './constants';
 export * from './hooks';


### PR DESCRIPTION
## Description
In version 1.3.1, the following import does not work. `AdMob` is undefined.
```js
import AdMob from '@react-native-admob/admob';
```

The change should work as shown below, but it doesn't seem to be the intended breaking change.
```js
import { AdMob } from '@react-native-admob/admob';
```

## Changes
Rolled back the old way.