### PR TITLE
fix: support undefined options for hooks

### DIFF
--- a/src/ads/AppOpenAdProvider.tsx
+++ b/src/ads/AppOpenAdProvider.tsx
@@ -14,7 +14,7 @@ export interface AppOpenAdProviderProps {
 
 const AppOpenAdProvider = ({
   unitId,
-  options,
+  options = {},
   children,
 }: AppOpenAdProviderProps) => {
   const [appOpenAd, setAppOpenAd] = useState<AppOpenAd | null>(null);

--- a/src/hooks/useInterstitialAd.ts
+++ b/src/hooks/useInterstitialAd.ts
@@ -13,7 +13,7 @@ import useFullScreenAd from './useFullScreenAd';
  */
 export default function useInterstitialAd(
   unitId: string | null,
-  options?: FullScreenAdOptions
+  options: FullScreenAdOptions = {}
 ): Omit<AdHookReturns, 'reward'> {
   const [interstitialAd, setInterstitialAd] = useState<InterstitialAd | null>(
     null

--- a/src/hooks/useRewardedAd.ts
+++ b/src/hooks/useRewardedAd.ts
@@ -13,7 +13,7 @@ import useFullScreenAd from './useFullScreenAd';
  */
 export default function useRewardedAd(
   unitId: string | null,
-  options?: FullScreenAdOptions
+  options: FullScreenAdOptions = {}
 ): AdHookReturns {
   const [rewardedAd, setRewardedAd] = useState<RewardedAd | null>(null);
 

--- a/src/hooks/useRewardedInterstitialAd.ts
+++ b/src/hooks/useRewardedInterstitialAd.ts
@@ -13,7 +13,7 @@ import useFullScreenAd from './useFullScreenAd';
  */
 export default function useRewardedInterstitialAd(
   unitId: string | null,
-  options?: FullScreenAdOptions
+  options: FullScreenAdOptions = {}
 ): AdHookReturns {
   const [rewardedInterstitialAd, setRewardedInterstitialAd] =
     useState<RewardedInterstitialAd | null>(null);


### PR DESCRIPTION
## Description

After applying useDeepCompareEffect, when options is undefined, it throws error.
To resolve this, added options parameter defaults to {}.