### PR TITLE
fix: initialize hook values when loadOnDismissed

### DIFF
--- a/src/ads/banner/BaseAd.tsx
+++ b/src/ads/banner/BaseAd.tsx
@@ -7,8 +7,7 @@ import {
   ViewStyle,
 } from 'react-native';
 
-import { GAMBannerAdProps } from '../..';
-import { BannerAdProps } from '../../types';
+import { BannerAdProps, GAMBannerAdProps } from '../../types';
 
 interface BannerAdState {
   style: StyleProp<ViewStyle>;

--- a/src/ads/fullscreen/AppOpenAd.ts
+++ b/src/ads/fullscreen/AppOpenAd.ts
@@ -1,7 +1,7 @@
 import {
-  AppOpenAdEvent,
   AppOpenAdOptions,
-  HandlerType,
+  FullScreenAdEvent,
+  FullScreenAdHandlerType,
   RequestOptions,
 } from '../../types';
 
@@ -15,10 +15,7 @@ const defaultOptions: AppOpenAdOptions = {
 
 let _appOpenRequest = 0;
 
-export default class AppOpenAd extends FullScreenAd<
-  AppOpenAdEvent,
-  HandlerType
-> {
+export default class AppOpenAd extends FullScreenAd {
   private constructor(
     requestId: number,
     unitId: string,
@@ -97,7 +94,10 @@ export default class AppOpenAd extends FullScreenAd<
    * @param event Event name
    * @param handler Event handler
    */
-  static addEventListener(event: AppOpenAdEvent, handler: HandlerType) {
+  static addEventListener(
+    event: FullScreenAdEvent,
+    handler: FullScreenAdHandlerType
+  ) {
     this.checkInstance();
     return this.sharedInstance!.addEventListener(event, handler);
   }

--- a/src/ads/fullscreen/FullScreenAd.ts
+++ b/src/ads/fullscreen/FullScreenAd.ts
@@ -7,8 +7,12 @@ import {
 import {
   AdType,
   AppOpenAdOptions,
+  FullScreenAdEvent,
+  FullScreenAdHandlerType,
   FullScreenAdOptions,
   RequestOptions,
+  RewardedAdEvent,
+  RewardedAdHandlerType,
 } from '../../types';
 
 const RNAdMobEvent = NativeModules.RNAdMobEvent;
@@ -39,14 +43,14 @@ const defaultOptions: FullScreenAdOptions = {
 };
 
 export default class FullScreenAd<
-  E extends string,
-  H extends (event?: any) => any
+  E extends RewardedAdEvent = FullScreenAdEvent,
+  H extends RewardedAdHandlerType = FullScreenAdHandlerType
 > {
-  type: AdType;
-  requestId: number;
-  unitId: string;
-  listeners: EmitterSubscription[];
-  options: FullScreenAdOptions | AppOpenAdOptions;
+  readonly type: AdType;
+  readonly requestId: number;
+  readonly unitId: string;
+  readonly options: FullScreenAdOptions | AppOpenAdOptions;
+  private listeners: EmitterSubscription[];
   private nativeModule: FullScreenAdInterface;
 
   protected constructor(

--- a/src/ads/fullscreen/InterstitialAd.ts
+++ b/src/ads/fullscreen/InterstitialAd.ts
@@ -1,17 +1,10 @@
-import {
-  FullScreenAdOptions,
-  HandlerType,
-  InterstitialAdEvent,
-} from '../../types';
+import { FullScreenAdOptions } from '../../types';
 
 import FullScreenAd from './FullScreenAd';
 
 let _interstitialRequest = 0;
 
-export default class InterstitialAd extends FullScreenAd<
-  InterstitialAdEvent,
-  HandlerType
-> {
+export default class InterstitialAd extends FullScreenAd {
   private constructor(
     requestId: number,
     unitId: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,15 +189,13 @@ export type FullScreenAdEvent =
   | 'adLoaded'
   | 'adFailedToLoad';
 
-export type InterstitialAdEvent = FullScreenAdEvent;
-
 export type RewardedAdEvent = FullScreenAdEvent | 'rewarded';
 
-export type AppOpenAdEvent = FullScreenAdEvent;
+export type FullScreenAdHandlerType = (() => void) | ((error: Error) => void);
 
-export type HandlerType = (() => void) | ((error: Error) => void);
-
-export type RewardedAdHandlerType = HandlerType | ((reward: Reward) => void);
+export type RewardedAdHandlerType =
+  | FullScreenAdHandlerType
+  | ((reward: Reward) => void);
 
 export interface Reward {
   type: string;


### PR DESCRIPTION
## Description
previously, ad state values were not initialized when ad is loaded via loadOnDismissed = true, so this fixes the issue.

