### PR TITLE
fix(android): fix current activity issue after restarting the app

### DIFF
--- a/android/src/main/java/com/rnadmob/admob/ActivityAwareJavaModule.java
+++ b/android/src/main/java/com/rnadmob/admob/ActivityAwareJavaModule.java
@@ -71,6 +71,7 @@ public abstract class ActivityAwareJavaModule extends ReactContextBaseJavaModule
     public void onHostDestroy() {
         if (application != null) {
             application.unregisterActivityLifecycleCallbacks(this);
+            application = null;
         }
     }
 }


### PR DESCRIPTION
## Description

If I follow the steps below on my android device (LG G8 ThinQ, Android 11), an error occurs.

1. present full screen ad : ok
2. Restart after closing the app
3. present full screen ad : error ('Current activity is null.')

The reason is as follows.

Step 2, `onHostDestroy` is called.
Step 3, `onHostResume` is called. but, the logic within the function is not executed because `application` is not null.

## Changes

Added code to initialize `application`.