### PR TITLE
fix(ios): fix a crash due to race condition on RNAdMobAdHolder

### DIFF
--- a/ios/RNAdMobAdHolder.swift
+++ b/ios/RNAdMobAdHolder.swift
@@ -1,19 +1,28 @@
 class RNAdMobAdHolder<T> {
+    private var adArrayQueue = DispatchQueue(label: "RNAdMobAdHolderQueue")
     private var adArray = Dictionary<Int, T>()
     
     func add(requestId: Int, ad: T) {
-        adArray.updateValue(ad, forKey: requestId)
+        adArrayQueue.sync {
+            adArray.updateValue(ad, forKey: requestId)
+        }
     }
     
     func get(requestId: Int) -> T? {
-        return adArray[requestId]
+        adArrayQueue.sync {
+            return adArray[requestId]
+        }
     }
     
     func remove(requestId: Int) {
-        adArray.removeValue(forKey: requestId)
+        adArrayQueue.sync {
+            adArray.removeValue(forKey: requestId)
+        }
     }
     
     func clear() {
-        adArray.removeAll()
+        adArrayQueue.async(flags: .barrier) {[weak self] in
+            self?.adArray.removeAll()
+        }
     }
 }


### PR DESCRIPTION
I faced on crashes like below.

```
EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x0000000000000000

Crashed: com.apple.main-thread
0  libswiftCore.dylib             0x2cf7ec swift_isUniquelyReferenced_nonNull_native + 10
1  libswiftCore.dylib             0x73914 Dictionary._Variant.removeValue(forKey:) + 1176
2  libswiftCore.dylib             0x6d300 Dictionary.removeValue(forKey:) + 80
```

```
Crashed: com.facebook.react.RNAdMobRewardedAdQueue
0  XXX                           0x10eb74 specialized __RawDictionaryStorage.find<A>(_:) + 56464 (<compiler-generated>:56464)
1  XXX                           0x109dcc specialized RNAdMobAdHolder.remove(requestId:) + 36584
2  XXX                           0x109aec @objc RNAdMobRewardedAd.destroyAd(_:) + 35848 (<compiler-generated>:35848)
```

It seems to be a problem that occurs because `Dictionary` is not thread-safe.
(Reference: https://github.com/awslabs/aws-mobile-appsync-sdk-ios/pull/501/files)