### PR TITLE
fix(android): fix a crash due to webview triggering focus request

### DIFF
--- a/android/src/main/java/com/rnadmob/admob/ads/banner/RNAdMobBannerView.java
+++ b/android/src/main/java/com/rnadmob/admob/ads/banner/RNAdMobBannerView.java
@@ -8,6 +8,7 @@ import static com.rnadmob.admob.ads.banner.RNAdMobBannerViewManager.EVENT_APP_EV
 import static com.rnadmob.admob.ads.banner.RNAdMobBannerViewManager.EVENT_SIZE_CHANGE;
 
 import android.content.Context;
+import android.view.ViewGroup;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;
@@ -49,6 +50,7 @@ public class RNAdMobBannerView extends ReactViewGroup implements AppEventListene
             adView.destroy();
         }
         adView = new AdManagerAdView(getContext());
+        adView.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
         adView.setAdListener(new AdListener() {
             @Override
             public void onAdLoaded() {


### PR DESCRIPTION
Since mid-November 2021, Google Ads banners have started to make focus requests, causing crashes and ARN on Android :
https://github.com/facebook/react-native/issues/32649

Google doesn't seem to want to do anything about it since they do not offer support for React Native:
https://groups.google.com/g/google-admob-ads-sdk/c/EsLEaoRjyNM

This pull request prevents webviews from triggering focus requests.